### PR TITLE
fix broken click handler on BurgerMenu preventing menu opening

### DIFF
--- a/client/src/ui/molecules/BurgerMenu.tsx
+++ b/client/src/ui/molecules/BurgerMenu.tsx
@@ -4,14 +4,39 @@ import { default as MenuIcon } from '@material-ui/icons/Menu';
 import Close from '@material-ui/icons/Close';
 import useOnClickOutside from '../hooks/useOnClickOutside';
 
-interface Props {
+interface BurgerMenuProps {
     items?: MenuItemType[];
 }
-const BurgerMenu: React.FC<Props> = ({ items }: Props): JSX.Element => {
-    const [expanded, setExpanded] = useState(false);
+
+type BurgerMenuContentProps = BurgerMenuProps & {
+    expanded: boolean;
+    setExpanded: (a: boolean) => void;
+};
+
+const BurgerMenuContent: React.FC<BurgerMenuContentProps> = ({
+    expanded,
+    setExpanded,
+    items,
+}: BurgerMenuContentProps): JSX.Element => {
     const panelRef = useRef<HTMLDivElement>();
     useOnClickOutside(panelRef, (): void => setExpanded(false));
+    return (
+        <div aria-expanded="true" className="burger_menu__overlay">
+            <div ref={panelRef} className="burger_menu__panel">
+                <button
+                    className="burger_menu__icon_button burger_menu__icon_button--collapse"
+                    onClick={(): void => setExpanded(!expanded)}
+                >
+                    <Close />
+                </button>
+                <Menu items={items} rootClassName="burger_menu" onLinkClick={(): void => setExpanded(false)} />
+            </div>
+        </div>
+    );
+};
 
+const BurgerMenu: React.FC<BurgerMenuProps> = ({ items }: BurgerMenuProps): JSX.Element => {
+    const [expanded, setExpanded] = useState(false);
     return (
         <div className="burger_menu">
             <button
@@ -21,19 +46,7 @@ const BurgerMenu: React.FC<Props> = ({ items }: Props): JSX.Element => {
             >
                 <MenuIcon />
             </button>
-            {expanded && (
-                <div aria-expanded="true" className="burger_menu__overlay">
-                    <div ref={panelRef} className="burger_menu__panel">
-                        <button
-                            className="burger_menu__icon_button burger_menu__icon_button--collapse"
-                            onClick={(): void => setExpanded(!expanded)}
-                        >
-                            <Close />
-                        </button>
-                        <Menu items={items} rootClassName="burger_menu" onLinkClick={(): void => setExpanded(false)} />
-                    </div>
-                </div>
-            )}
+            {expanded && <BurgerMenuContent expanded={expanded} setExpanded={setExpanded} items={items} />}
         </div>
     );
 };

--- a/client/src/ui/molecules/ProfileDropdown.tsx
+++ b/client/src/ui/molecules/ProfileDropdown.tsx
@@ -12,7 +12,6 @@ const ProfileDropdown: React.FC<Props> = ({ name }: Props): JSX.Element => {
     const [expanded, setExpanded]: [boolean, Function] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>();
     useOnClickOutside(dropdownRef, (): void => setExpanded(false));
-
     return (
         <div ref={dropdownRef} className="profile_dropdown">
             <button


### PR DESCRIPTION
inner ref issue was causing the BurgerMenus expanded state to trigger true and then false on click. This meant menu never showed. Separating the content and outer component out and applying hook only to inner content fixes this.