### PR TITLE
Remove error suppression

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -10,6 +10,6 @@ module.exports = {
         '\\.(css|scss)$': '<rootDir>/test-utils/styleTransform.js',
     },
     globals: {
-        API_HOST: ''
-      },
+        API_HOST: '',
+    },
 };

--- a/client/src/core/components/App.test.tsx
+++ b/client/src/core/components/App.test.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
 import * as ApolloReactHooks from '@apollo/react-hooks';
 import { ApolloProviderProps } from '@apollo/react-common/lib/context/ApolloProvider';
@@ -22,7 +22,7 @@ describe('App', (): void => {
         ];
         // Mock out instance of ApolloProvider so we can use a mocked provider instead
         jest.spyOn(ApolloReactHooks, 'ApolloProvider').mockImplementation(
-            ({ children }: ApolloProviderProps<unknown>): JSX.Element => apolloWrapper(mockQueryResponse)({children}),
+            ({ children }: ApolloProviderProps<unknown>): JSX.Element => apolloWrapper(mockQueryResponse)({ children }),
         );
         expect((): RenderResult => render(<App />)).not.toThrow();
     });

--- a/client/test-utils/setup.js
+++ b/client/test-utils/setup.js
@@ -7,15 +7,3 @@ require('whatwg-fetch');
 require('@testing-library/jest-dom/extend-expect');
 const jestDom = require('@testing-library/jest-dom');
 expect.extend({...jestDom});
-
-const consoleError = console.error;
-/*
-*  Temp suppression of act wrapper error to be fixed in react-dom 16.9
-*  update: 16.9 did not fix this. Needs further investigating.
-*/
-jest.spyOn(console, 'error').mockImplementation((...args) => {
-  if (!args[0].includes('Warning: An update to %s inside a test was not wrapped in act')) {
-    consoleError(...args);
-  }
-});
-


### PR DESCRIPTION
Removing the `act` error suppression seems to no longer produce errors when running tests locally (I think this error was originally to do do with async processes setting state in lifecycles which should have been fixed in `react@16.9`).

.... also some lint fixes.