### PR TITLE
tree shake icon imports to reduce bundle size

### DIFF
--- a/client/src/dashboard/components/SubmissionEntry.tsx
+++ b/client/src/dashboard/components/SubmissionEntry.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Delete } from '@material-ui/icons';
+import Delete from '@material-ui/icons/Delete';
 import moment from 'moment';
 import useModal from '../../ui/hooks/useModal';
 import { Modal } from '../../ui/atoms';


### PR DESCRIPTION
Prevents the build from bundling all of `@material-ui/core` which was over 2Mb. Did attempt to find some linting fix solutions for this so it doesn't happen again in future but decided to raise another issue.