### PR TITLE
Add a strawman token interface

### DIFF
--- a/continuum-auth/src/jwt.ts
+++ b/continuum-auth/src/jwt.ts
@@ -26,7 +26,7 @@ export const decodeJournalToken = (token: string): Option<JournalAuthToken> => {
   const {
     journal_jwt: { secret }
   } = config;
-  // This needs to know about the journal secret in order to verify it. The two systems should use different tokens
+  // This needs to know about the journal secret in order to verify it. The two systems should use different tokens & secrets
 
   try {
     return Option.of(verify(token, secret) as JournalAuthToken);

--- a/continuum-auth/src/use-cases/authenticate.ts
+++ b/continuum-auth/src/use-cases/authenticate.ts
@@ -13,10 +13,11 @@ export interface UserIdentity { // don't forget this is merged with the rest of 
   token_id: string; // Generated, unique per token
   token_version: '0.1-alpha'; // Generated, hardcoded
   identity: { // Unique per user, lookup from profiles, people, user management services
-    orcid: string;
-    libero_id?: string;
-    profiles_id?: string;
-    people_id?: string;
+    user_id: string;
+    external: Array<{
+      id: string;
+      domain: string; // e.g. "elife-profiles", "elife-people", "orcid"
+    }>;
   };
 
   // Generic user roles, basically to know which
@@ -67,8 +68,17 @@ export const Authenticate = (profilesService: ProfilesRepo) => (
               token_id: v4(),
               token_version: "0.1-alpha",
               identity: {
-                orcid: profile.orcid,
-                profiles_id: profile.id,
+                id: v4(), // Warning: this needs to be a useful value at some point
+                external: [
+                  {
+                    id: profile.id,
+                    domain: "elife-profiles"
+                  },
+                  {
+                    id: profile.orcid,
+                    domain: "orcid",
+                  }
+                ]
               },
               roles: [{journal: "elife", kind: "author"}],
               meta: null,

--- a/continuum-auth/src/use-cases/authenticate.ts
+++ b/continuum-auth/src/use-cases/authenticate.ts
@@ -68,7 +68,7 @@ export const Authenticate = (profilesService: ProfilesRepo) => (
               token_id: v4(),
               token_version: "0.1-alpha",
               identity: {
-                id: v4(), // Warning: this needs to be a useful value at some point
+                user_id: v4(), // TODO: this needs to be a useful value at some point
                 external: [
                   {
                     id: profile.id,

--- a/continuum-auth/src/use-cases/authenticate.ts
+++ b/continuum-auth/src/use-cases/authenticate.ts
@@ -6,16 +6,40 @@ import { ProfilesRepo } from "../repo/profiles";
 import { v4 } from "uuid";
 import config from '../config';
 
+// NOTE: This is a duplicate from server/src/modules/auth/types.ts
+// we just haven't set up a way of having a shared types module
+
+export interface UserIdentity { // don't forget this is merged with the rest of the JWT standard fields
+  token_id: string; // Generated, unique per token
+  token_version: '0.1-alpha'; // Generated, hardcoded
+  identity: { // Unique per user, lookup from profiles, people, user management services
+    orcid: string;
+    libero_id?: string;
+    profiles_id?: string;
+    people_id?: string;
+  };
+
+  // Generic user roles, basically to know which
+  // So a user is associated with a `journal` when they've got a role with it?
+  roles: Array<{
+    journal: string; // e.g. "elife"
+    kind: string; // e.g. "author", "reviewer", e.t.c
+  }>;
+  meta: unknown; // could be anything
+}
+
+// End of duplicated code
+
 // This is the endpoint that does the actual token exchange/user lookup and signing the output token
 // And yeah, I know the controller/usecase code shouldn't be mixed but idec, we can refactor it at some point
 // The tokens will take the following shape:
-const example_token = {
-  iss: "journal--prod",
-  iat: 1567503944,
-  exp: 1567504004,
-  id: "jfrdocq8",
-  "new-session": true
-};
+// const example_token = {
+//   iss: "journal--prod",
+//   iat: 1567503944,
+//   exp: 1567504004,
+//   id: "jfrdocq8",
+//   "new-session": true
+// };
 
 export const Authenticate = (profilesService: ProfilesRepo) => (
   req: Request,
@@ -39,7 +63,17 @@ export const Authenticate = (profilesService: ProfilesRepo) => (
             logger.info("getProfile", profile);
             // TODO: Calculate user-role
 
-            const payload = { token_id: v4(), profile, user_roles: ["author"] };
+            const payload: UserIdentity = { 
+              token_id: v4(),
+              token_version: "0.1-alpha",
+              identity: {
+                orcid: profile.orcid,
+                profiles_id: profile.id,
+              },
+              roles: [{journal: "elife", kind: "author"}],
+              meta: null,
+            };
+
             const output_token = encode(payload);
 
             res.redirect(`${authorised_redirect_url}#${output_token}`);

--- a/continuum-auth/src/use-cases/index.ts
+++ b/continuum-auth/src/use-cases/index.ts
@@ -1,8 +1,10 @@
 import { Request, Response } from "express";
+import { DomainLogger as logger } from '../logger';
 
 export * from "./authenticate";
 export * from "./login";
 
 export const HealthCheck = (deps: unknown) => (req: Request, res: Response) => {
+  logger.info("healthCheck");
   res.json({ ok: true });
 };

--- a/continuum-auth/src/use-cases/login.ts
+++ b/continuum-auth/src/use-cases/login.ts
@@ -9,7 +9,7 @@ const {
 } = config;
 
 export const Login = (req: Request, res: Response) => {
-  logger.info("Redirecting request", { login_redirect_url });
+  logger.info("loginRedirect", { login_redirect_url });
 
   res.redirect(login_redirect_url);
 };

--- a/server/src/modules/auth/graphql.guard.ts
+++ b/server/src/modules/auth/graphql.guard.ts
@@ -3,7 +3,6 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-
 export class GqlAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
     const ctx = GqlExecutionContext.create(context);

--- a/server/src/modules/auth/types.ts
+++ b/server/src/modules/auth/types.ts
@@ -4,3 +4,23 @@ export interface JwtPayload {
   iat: number;
   iss: string;
 }
+
+// TODO: Move this into somewhere else - no copy & paste!
+export interface UserIdentity { // don't forget this is merged with the rest of the JWT standard fields
+  token_id: string; // Generated, unique per token
+  token_version: '0.1-alpha'; // Generated, hardcoded
+  identity: { // Unique per user, lookup from profiles, people, user management services
+    orcid: string;
+    libero_id?: string;
+    profiles_id?: string;
+    people_id?: string;
+  };
+
+  // Generic user roles, basically to know which
+  // So a user is associated with a `journal` when they've got a role with it?
+  roles: Array<{
+    journal: string; // e.g. "elife"
+    kind: string; // e.g. "author", "reviewer", e.t.c
+  }>;
+  meta: unknown; // could be anything
+}

--- a/server/src/modules/auth/types.ts
+++ b/server/src/modules/auth/types.ts
@@ -10,10 +10,11 @@ export interface UserIdentity { // don't forget this is merged with the rest of 
   token_id: string; // Generated, unique per token
   token_version: '0.1-alpha'; // Generated, hardcoded
   identity: { // Unique per user, lookup from profiles, people, user management services
-    orcid: string;
-    libero_id?: string;
-    profiles_id?: string;
-    people_id?: string;
+    user_id: string;
+    external: Array<{
+      id: string;
+      domain: string; // e.g. "elife-profiles", "elife-people", "orcid"
+    }>;
   };
 
   // Generic user roles, basically to know which


### PR DESCRIPTION
Some requirements:
- [x] User identification within libero
- [ ] Not reliant on eLife infrastructure
- [x] Multitennancy (i.e. many journals per instance of reviewer)
- [ ] Guest access (i.e. allows 'magic link' functionality)
- [x] Provides information about a user's role per journal
- [ ] -- other stuff