### PR TITLE
Push images to docker hub on master:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".scripts"]
+	path = .scripts
+	url = https://github.com/libero/scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - TEST_SUITE=server_ci
   - TEST_SUITE=client_ci
   - TEST_SUITE=continuum-auth_ci
+  - IMAGE_TAG=$TRAVIS_COMMIT
 
 services:
   - docker
@@ -24,3 +25,6 @@ jobs:
     - stage: Integration Tests
       name: "Browser Tests"
       script: make run_browser_tests
+
+after_success:
+    - .scripts/travis/push-image.sh reviewer_server

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ help:
 
 DOCKER_NETWORK_NAME=reviewer_build
 
-TRAVIS_COMMIT ?= "local"
+IMAGE_TAG ?= "local"
 
-DC_BUILD = IMAGE_TAG=${TRAVIS_COMMIT} docker-compose -f docker-compose.build.yml
+DC_BUILD = IMAGE_TAG=${IMAGE_TAG} docker-compose -f docker-compose.build.yml
 
 ###########################
 #

--- a/client/Dockerfile.application
+++ b/client/Dockerfile.application
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_client_webpack:${image_tag} AS built
+FROM libero/reviewer_client_webpack:${image_tag} AS built
 FROM nginx:1-alpine
 
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>

--- a/client/Dockerfile.webpack
+++ b/client/Dockerfile.webpack
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_client_packages:${image_tag}
+FROM libero/reviewer_client_packages:${image_tag}
 
 WORKDIR /app
 

--- a/continuum-auth/Dockerfile.application
+++ b/continuum-auth/Dockerfile.application
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_continuum-auth_typescript:${image_tag} AS auth_typescript
+FROM libero/reviewer_continuum-auth_typescript:${image_tag} AS auth_typescript
 
 FROM node:10-alpine
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>

--- a/continuum-auth/Dockerfile.typescript
+++ b/continuum-auth/Dockerfile.typescript
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_continuum-auth_packages:${image_tag} AS auth_packages
+FROM libero/reviewer_continuum-auth_packages:${image_tag} AS auth_packages
 
 FROM node:10-alpine
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: 'server/'
       dockerfile: 'Dockerfile.packages'
-    image: liberoadmin/reviewer_server_packages:${IMAGE_TAG}
-    networks: 
+    image: libero/reviewer_server_packages:${IMAGE_TAG}
+    networks:
         - 'reviewer_build'
   server_typescript:
     build:
@@ -14,10 +14,10 @@ services:
       dockerfile: "Dockerfile.typescript"
       args:
         image_tag: ${IMAGE_TAG}
-    image: liberoadmin/reviewer_server_typescript:${IMAGE_TAG}
+    image: libero/reviewer_server_typescript:${IMAGE_TAG}
     depends_on:
       - server_npm
-    networks: 
+    networks:
         - 'reviewer_build'
   reviewer_server:
     build:
@@ -25,11 +25,11 @@ services:
       dockerfile: "Dockerfile.application"
       args:
         image_tag: ${IMAGE_TAG}
-    image: liberoadmin/reviewer_server:${IMAGE_TAG}
+    image: libero/reviewer_server:${IMAGE_TAG}
     depends_on:
       - server_npm
       - server_typescript
-    networks: 
+    networks:
         - 'reviewer_build'
 
   # Client
@@ -37,8 +37,8 @@ services:
     build:
       context: 'client/'
       dockerfile: 'Dockerfile.packages'
-    image: liberoadmin/reviewer_client_packages:${IMAGE_TAG}
-    networks: 
+    image: libero/reviewer_client_packages:${IMAGE_TAG}
+    networks:
         - 'reviewer_build'
 
   client_webpack:
@@ -47,10 +47,10 @@ services:
       dockerfile: 'Dockerfile.webpack'
       args:
         image_tag: ${IMAGE_TAG}
-    image: liberoadmin/reviewer_client_webpack:${IMAGE_TAG}
+    image: libero/reviewer_client_webpack:${IMAGE_TAG}
     depends_on:
       - client_npm
-    networks: 
+    networks:
         - 'reviewer_build'
 
   reviewer_client:
@@ -59,7 +59,7 @@ services:
       dockerfile: "Dockerfile.application"
       args:
         image_tag: "${IMAGE_TAG}"
-    image: liberoadmin/reviewer_client:${IMAGE_TAG}
+    image: libero/reviewer_client:${IMAGE_TAG}
     command: >
       /bin/sh -c
       "envsubt '
@@ -72,7 +72,7 @@ services:
     depends_on:
       - client_npm
       - client_webpack
-    networks: 
+    networks:
         - 'reviewer_build'
 
   # continuum-auth
@@ -80,8 +80,8 @@ services:
     build:
       context: 'continuum-auth/'
       dockerfile: 'Dockerfile.packages'
-    image: liberoadmin/reviewer_continuum-auth_packages:${IMAGE_TAG}
-    networks: 
+    image: libero/reviewer_continuum-auth_packages:${IMAGE_TAG}
+    networks:
         - 'reviewer_build'
   continuum-auth_typescript:
     build:
@@ -89,10 +89,10 @@ services:
       dockerfile: "Dockerfile.typescript"
       args:
         image_tag: ${IMAGE_TAG}
-    image: liberoadmin/reviewer_continuum-auth_typescript:${IMAGE_TAG}
+    image: libero/reviewer_continuum-auth_typescript:${IMAGE_TAG}
     depends_on:
       - continuum-auth_npm
-    networks: 
+    networks:
         - 'reviewer_build'
   reviewer_continuum-auth:
     build:
@@ -100,11 +100,11 @@ services:
       dockerfile: "Dockerfile.application"
       args:
         image_tag: ${IMAGE_TAG}
-    image: liberoadmin/reviewer_continuum-auth:${IMAGE_TAG}
+    image: libero/reviewer_continuum-auth:${IMAGE_TAG}
     depends_on:
       - continuum-auth_npm
       - continuum-auth_typescript
-    networks: 
+    networks:
         - 'reviewer_build'
 networks:
   reviewer_build:

--- a/server/Dockerfile.application
+++ b/server/Dockerfile.application
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_server_typescript:${image_tag} as server_typescript
+FROM libero/reviewer_server_typescript:${image_tag} as server_typescript
 
 FROM node:10-alpine
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>

--- a/server/Dockerfile.typescript
+++ b/server/Dockerfile.typescript
@@ -1,6 +1,6 @@
 ARG image_tag=latest
 
-FROM liberoadmin/reviewer_server_packages:${image_tag} AS server_packages
+FROM libero/reviewer_server_packages:${image_tag} AS server_packages
 FROM node:10-alpine
 MAINTAINER eLife Reviewer Product Team <reviewer-product@elifesciences.org>
 


### PR DESCRIPTION
- Set IMAGE_TAG to TRAVIS_COMMIT only on travis environment
- For local ci use "local" and decouple from TRAVIS_COMMIT
- Added .scripts gitsubmodule from libero/scripts
- Changed image names liberoadmin/* to libero/* as that is handled by push-image.sh script