### PR TITLE
231 excluded toggle

### DIFF
--- a/client/src/ui/atoms/TextField.tsx
+++ b/client/src/ui/atoms/TextField.tsx
@@ -7,7 +7,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
     invalid?: boolean;
     labelText: string;
 }
-const TextField = ({ id, labelText, placeholder, invalid, helperText, ...rest }: Props): JSX.Element => (
+const TextField = ({ id, labelText, invalid, helperText, ...rest }: Props): JSX.Element => (
     <div className="text-field">
         <label htmlFor={id} className="typography__label typography__label--primary">
             {labelText}

--- a/client/src/ui/molecules/ExcludedToggle.tsx
+++ b/client/src/ui/molecules/ExcludedToggle.tsx
@@ -8,22 +8,35 @@ interface Props {
     open?: boolean;
 }
 
-const ExcludedToggle = ({ open = false, togglePrefixText, toggleActionText, children, panelHeading }: Props): JSX.Element => {
+const ExcludedToggle = ({
+    open = false,
+    togglePrefixText,
+    toggleActionText,
+    children,
+    panelHeading,
+}: Props): JSX.Element => {
     const [opened, setOpened] = useState(open);
     return (
         <Fragment>
             {opened ? (
                 <div className="excluded-toggle__panel">
-                  <div className="excluded-toggle__panel-header">
-                    <h3 className="excluded-toggle__panel-heading">{panelHeading}</h3>
-                    <button className="excluded-toggle__close-button" onClick={(): void => setOpened(!opened)}><Close />close</button>
-                  </div>
-                  {children}
+                    <div className="excluded-toggle__panel-header">
+                        <h3 className="excluded-toggle__panel-heading">{panelHeading}</h3>
+                        <button className="excluded-toggle__close-button" onClick={(): void => setOpened(!opened)}>
+                            <Close />
+                            close
+                        </button>
+                    </div>
+                    {children}
                 </div>
             ) : (
                 <span className="excluded-toggle__label">
                     {togglePrefixText}
-                    <button className="excluded-toggle__action" aria-expanded={opened} onClick={(): void => setOpened(!opened)}>
+                    <button
+                        className="excluded-toggle__action"
+                        aria-expanded={opened}
+                        onClick={(): void => setOpened(!opened)}
+                    >
                         {toggleActionText}
                     </button>
                     ?

--- a/client/src/ui/molecules/ExcludedToggle.tsx
+++ b/client/src/ui/molecules/ExcludedToggle.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode, Fragment, useState } from 'react';
+import Close from '@material-ui/icons/Close';
+interface Props {
+    children?: ReactNode;
+    panelHeading?: string;
+    togglePrefixText: string;
+    toggleActionText: string;
+    open?: boolean;
+}
+
+const ExcludedToggle = ({ open = false, togglePrefixText, toggleActionText, children, panelHeading }: Props): JSX.Element => {
+    const [opened, setOpened] = useState(open);
+    return (
+        <Fragment>
+            {opened ? (
+                <div className="excluded-toggle__panel">
+                  <div className="excluded-toggle__panel-header">
+                    <h3 className="excluded-toggle__panel-heading">{panelHeading}</h3>
+                    <button className="excluded-toggle__close-button" onClick={(): void => setOpened(!opened)}><Close /></button>
+                  </div>
+                  {children}
+                </div>
+            ) : (
+                <span className="excluded-toggle__label">
+                    {togglePrefixText}
+                    <button className="excluded-toggle__action" aria-expanded={opened} onClick={(): void => setOpened(!opened)}>
+                        {toggleActionText}
+                    </button>
+                    ?
+                </span>
+            )}
+        </Fragment>
+    );
+};
+
+export default ExcludedToggle;

--- a/client/src/ui/molecules/ExcludedToggle.tsx
+++ b/client/src/ui/molecules/ExcludedToggle.tsx
@@ -16,7 +16,7 @@ const ExcludedToggle = ({ open = false, togglePrefixText, toggleActionText, chil
                 <div className="excluded-toggle__panel">
                   <div className="excluded-toggle__panel-header">
                     <h3 className="excluded-toggle__panel-heading">{panelHeading}</h3>
-                    <button className="excluded-toggle__close-button" onClick={(): void => setOpened(!opened)}><Close /></button>
+                    <button className="excluded-toggle__close-button" onClick={(): void => setOpened(!opened)}><Close />close</button>
                   </div>
                   {children}
                 </div>

--- a/client/src/ui/molecules/ExtendedToggle.test.tsx
+++ b/client/src/ui/molecules/ExtendedToggle.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { cleanup, render, RenderResult, fireEvent } from '@testing-library/react';
+import ExcludedToggle from './ExcludedToggle';
+
+describe('ExcludedToggle', (): void => {
+    afterEach(cleanup);
+
+    it('should render correctly', (): void => {
+        expect(
+            (): RenderResult => render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" />),
+        ).not.toThrow();
+    });
+
+    it('should display its prefix and action text together', (): void => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" />);
+        expect(container.querySelector('.excluded-toggle__label').textContent).toContain('Do an action');
+    });
+
+    it('should not display panel when closed', (): void => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" />);
+        expect(container.querySelector('.excluded-toggle__label')).toBeInTheDocument();
+        expect(container.querySelector('.excluded-toggle__panel')).toBeNull();
+    });
+
+    it('should display the panel and not the toggle text when passed open', (): void => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" open />);
+        expect(container.querySelector('.excluded-toggle__label')).toBeNull();
+        expect(container.querySelector('.excluded-toggle__panel')).toBeInTheDocument();
+    });
+
+    it('should display the panel and not the toggle text when the toggle text action button is clicked', async (): Promise<
+        void
+    > => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" />);
+        expect(container.querySelector('.excluded-toggle__panel')).toBeNull();
+        await fireEvent.click(container.querySelector('.excluded-toggle__action'));
+        expect(container.querySelector('.excluded-toggle__panel')).toBeInTheDocument();
+        expect(container.querySelector('.excluded-toggle__label')).toBeNull();
+    });
+
+    it('should display a close icon in the toggled panel', (): void => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" open />);
+        expect(container.querySelector('.excluded-toggle__close-button')).toBeInTheDocument();
+    });
+
+    it('should should display the toggle text and not the panel if the close button is clicked', async (): Promise<
+        void
+    > => {
+        const { container } = render(<ExcludedToggle togglePrefixText="Do an " toggleActionText="action" open />);
+        expect(container.querySelector('.excluded-toggle__label')).toBeNull();
+        await fireEvent.click(container.querySelector('.excluded-toggle__close-button'));
+        expect(container.querySelector('.excluded-toggle__label')).toBeInTheDocument();
+        expect(container.querySelector('.excluded-toggle__panel')).toBeNull();
+    });
+
+    it('passed panel heading should display in the heading block of the panel', (): void => {
+        const { container } = render(
+            <ExcludedToggle panelHeading="Some Heading" togglePrefixText="Do an " toggleActionText="action" open />,
+        );
+        expect(container.querySelector('.excluded-toggle__panel-heading')).toHaveTextContent('Some Heading');
+    });
+
+    it('should display children within panel', (): void => {
+        const { container } = render(
+            <ExcludedToggle panelHeading="Some Heading" togglePrefixText="Do an " toggleActionText="action" open>
+                <span className="testSpan">Some test text</span>
+            </ExcludedToggle>,
+        );
+        expect(container.querySelector('.testSpan')).toBeInTheDocument();
+        expect(container.querySelector('.excluded-toggle__panel')).toHaveTextContent('Some test text');
+    });
+});

--- a/client/src/ui/molecules/index.ts
+++ b/client/src/ui/molecules/index.ts
@@ -1,4 +1,5 @@
 export { default as BurgerMenu } from './BurgerMenu';
+export { default as ExcludedToggle } from './ExcludedToggle';
 export { default as Menu } from './Menu';
 export { default as OrcidDetails, AuthorDetails } from './OrcidDetails';
 export { default as ProfileDropdown } from './ProfileDropdown';

--- a/client/src/ui/stories/molecules/ExcludedToggle.stories.tsx
+++ b/client/src/ui/stories/molecules/ExcludedToggle.stories.tsx
@@ -1,0 +1,34 @@
+import React, { Fragment } from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs, boolean, number } from '@storybook/addon-knobs';
+import { TextField } from '../../atoms';
+import { ExcludedToggle } from '../../molecules';
+import '../../../core/styles/index.scss';
+import centered from '@storybook/addon-centered/react';
+
+storiesOf('ui | molecules/ExcludedToggle', module)
+    .addDecorator(withKnobs)
+    .addDecorator(centered)
+    .add(
+        'ExcludedToggle',
+        (): JSX.Element => {
+            const togglePrefixText = text('Toggle prefix text', 'Would you like to ');
+            const toggleActionText = text('Toggle action text', 'exclude a senior editor');
+            const panelHeading = text('Panel heading', 'Excluded a senior editor');
+            const toggleContent = boolean('Display inner content', false);
+            const containerWidth = number('Container width', 600)
+            return (
+                <div style={{width: `${containerWidth}px`}}>
+                  <ExcludedToggle togglePrefixText={togglePrefixText} toggleActionText={toggleActionText} panelHeading={panelHeading}>
+                      {toggleContent && (
+                          <Fragment>
+                              <TextField id="someInput1" labelText="Some Lablel" />
+                              <TextField id="someInput2" labelText="Some Lablel" />
+                              <TextField id="someInput3" labelText="Some Lablel" />
+                          </Fragment>
+                      )}
+                  </ExcludedToggle>
+                </div>
+            );
+        },
+    );

--- a/client/src/ui/stories/molecules/ExcludedToggle.stories.tsx
+++ b/client/src/ui/stories/molecules/ExcludedToggle.stories.tsx
@@ -16,18 +16,22 @@ storiesOf('ui | molecules/ExcludedToggle', module)
             const toggleActionText = text('Toggle action text', 'exclude a senior editor');
             const panelHeading = text('Panel heading', 'Excluded a senior editor');
             const toggleContent = boolean('Display inner content', false);
-            const containerWidth = number('Container width', 600)
+            const containerWidth = number('Container width', 600);
             return (
-                <div style={{width: `${containerWidth}px`}}>
-                  <ExcludedToggle togglePrefixText={togglePrefixText} toggleActionText={toggleActionText} panelHeading={panelHeading}>
-                      {toggleContent && (
-                          <Fragment>
-                              <TextField id="someInput1" labelText="Some Lablel" />
-                              <TextField id="someInput2" labelText="Some Lablel" />
-                              <TextField id="someInput3" labelText="Some Lablel" />
-                          </Fragment>
-                      )}
-                  </ExcludedToggle>
+                <div style={{ width: `${containerWidth}px` }}>
+                    <ExcludedToggle
+                        togglePrefixText={togglePrefixText}
+                        toggleActionText={toggleActionText}
+                        panelHeading={panelHeading}
+                    >
+                        {toggleContent && (
+                            <Fragment>
+                                <TextField id="someInput1" labelText="Some Lablel" />
+                                <TextField id="someInput2" labelText="Some Lablel" />
+                                <TextField id="someInput3" labelText="Some Lablel" />
+                            </Fragment>
+                        )}
+                    </ExcludedToggle>
                 </div>
             );
         },

--- a/client/src/ui/styles/ExcludedToggle.scss
+++ b/client/src/ui/styles/ExcludedToggle.scss
@@ -1,0 +1,37 @@
+.excluded-toggle__panel {
+  box-sizing: border-box;
+  padding: 1.5rem;
+  border-radius: 0.188rem;
+  border: $border;
+}
+
+.excluded-toggle__label {
+  line-height: 1.5rem;
+}
+
+.excluded-toggle__action {
+  color: $colourPrimary;
+  border: none;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+  &:hover{
+    text-decoration: underline;
+  }
+}
+
+.excluded-toggle__panel-header {
+  display: flex;
+  align-items: flex-start
+}
+
+.excluded-toggle__panel-heading {
+  flex-grow: 1;
+  margin-top: 0;
+}
+
+.excluded-toggle__close-button {
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/client/src/ui/styles/ExcludedToggle.scss
+++ b/client/src/ui/styles/ExcludedToggle.scss
@@ -34,4 +34,7 @@
   border: none;
   padding: 0;
   cursor: pointer;
+  color: $colourTextSecondary;
+  //hide the inner text used for accessibility
+  font-size: 0;
 }

--- a/client/src/ui/styles/index.scss
+++ b/client/src/ui/styles/index.scss
@@ -11,6 +11,7 @@
 
 /* All molecule ui components should live here */
 @import './BurgerMenu';
+@import './ExcludedToggle.scss';
 @import './Modal';
 @import './Menu';
 @import './OrcidDetails.scss';


### PR DESCRIPTION
Adds an `ExcludedToggle` component needed for the configurable form. 

Closes #231 

removes the destructured placeholder param from TextField as it is passed down using the `{...rest}` spread. (have checked and all working in storybook).