### PR TITLE
Added example docker compose override 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ typings/
 # dotenv environment variables file
 .env
 
+# docker compose
+.docker-compose.override.yml
+
 # next.js build output
 .next
 

--- a/docker-compose.override-macos.yml
+++ b/docker-compose.override-macos.yml
@@ -1,0 +1,12 @@
+## override file for mac
+
+version: '3'
+services:
+  client:
+    command: ["bash", "-c", "yarn --network-timeout 1000000000 && yarn run start --host 0.0.0.0"]
+    volumes:
+      - ./client/:/client/:delegated
+      - client_node_modules:/client/node_modules
+
+volumes:
+  client_node_modules:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -40,6 +40,16 @@ yarn run start:dev
 
 ## Running in containers
 
+### Mac OS X
+Docker performance can be slow on mac and result in Yarn install throwing errors. A docker compose override file attempts to mitigate that. Copy the
+example file:
+```
+cp docker-compose.override-macos.yml docker-compose.override.yml
+```
+
+before starting the containers.
+
+
 Bring up all the containers using docker compose:
 
 ```


### PR DESCRIPTION
This allows someone developing on mac not to get connection errors due to yarn timing out on yarn install for client container

also tries out delegated volumes to see if that makes it quicker