### PR TITLE
add banner component

### DIFF
--- a/client/src/ui/atoms/Banner.test.tsx
+++ b/client/src/ui/atoms/Banner.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { cleanup, render, RenderResult } from '@testing-library/react';
+import Banner from './Banner';
+
+describe('Banner', ():void => {
+  afterEach(cleanup);
+  it('should render correctly', (): void => {
+    expect((): RenderResult => render(<Banner />)).not.toThrow();
+  });
+  it('renders children as content', ():void => {
+    const { getByText } = render(<Banner>SomeTestText</Banner>);
+    expect(getByText('SomeTestText')).toBeInTheDocument();
+  });
+});

--- a/client/src/ui/atoms/Banner.tsx
+++ b/client/src/ui/atoms/Banner.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from 'react';
+
+interface Props {
+  children?: ReactNode
+}
+const Banner = ({ children }: Props): JSX.Element => (
+  <div className="banner">
+    { children }
+  </div>
+)
+export default Banner;

--- a/client/src/ui/atoms/index.ts
+++ b/client/src/ui/atoms/index.ts
@@ -1,5 +1,6 @@
 export { default as AppBar } from './AppBar';
 export { default as AppBarIcon } from './AppBarIcon';
+export { default as Banner } from './Banner';
 export { default as Button } from './Button';
 export { default as TextField } from './TextField';
 export { default as SelectField } from './SelectField';

--- a/client/src/ui/stories/atoms/AlertBanner.stories.tsx
+++ b/client/src/ui/stories/atoms/AlertBanner.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { Banner } from '../../atoms';
+import '../../../core/styles/index.scss';
+
+storiesOf('ui | atoms/Banner', module)
+    .addDecorator(withKnobs)
+    .add(
+        'Banner',
+        (): JSX.Element => {
+            const content = text('Content', 'Maximum 6 people selected');
+            return <Banner>{ content }</Banner>;
+        },
+    );

--- a/client/src/ui/styles/Banner.scss
+++ b/client/src/ui/styles/Banner.scss
@@ -1,0 +1,8 @@
+.banner {
+  position: fixed;
+  width:100%;
+  padding: 1rem;
+  background-color: $colourPrimary;
+  color: $white;
+  text-align: center;
+}

--- a/client/src/ui/styles/index.scss
+++ b/client/src/ui/styles/index.scss
@@ -1,6 +1,7 @@
 /* All atom ui components should live here */
 @import './AppBar';
 @import './AppBarIcon';
+@import './Banner';
 @import './Button';
 @import './Checkbox.scss';
 @import './ImageWithAttributions';


### PR DESCRIPTION
Adds a fixed banner component.

Closes #315 

I've not included any background colour change props in this initial pr as theres no use-cases for anything other than primary blue right now.