### PR TITLE
Fix start script after Nathan testing

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # Symlink in the environment if missing
-if [ ! -e .env ] ; then ln -s .env .env.example ; fi
+if [ ! -e .env ] ; then ln -s .env.example .env ; fi
 
 # Create an override file if not present
 if [ ! -e docker-compose.override.yml ] ; then echo "version: '3'" > docker-compose.override.yml ; fi


### PR DESCRIPTION
Nathan was the first 'new-to-the-project' person to use the `start.sh` script after it was written. There was a bug and this should fix it.

Manually tested.