### PR TITLE
docs: remove orphan reference "Malcolm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 # Welcome to Libero Reviewer
 
-Malcolm (https://www.imdb.com/title/tt0107290/fullcredits) is a Proof of Concept for eLife Sciences' Libero Reviewer Product.
-
 [The Product Roadmap](https://trello.com/b/NShRx4VE/libero-reviewer-product-roadmap)
 for Libero Reviewer has been revisted after the launch of libero.pub site. This roadmap
 combined with the site sets out the objectives and our commitments for the product vision.


### PR DESCRIPTION
"Malcolm" seems confusing as it's not mentioned anywhere but the top of the README (apart from being the sample name in one test). As I've not heard Reviewer referred to as "Malcolm" for a while, this PR removes that reference. Aiming for the scout rule here, but feel free to close this if it's an accidental "Nedry" 😄 