### PR TITLE
make flushPromises a test-util

### DIFF
--- a/client/src/ui/molecules/ManuscriptUpload.test.tsx
+++ b/client/src/ui/molecules/ManuscriptUpload.test.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { render, RenderResult, fireEvent, cleanup, act, queryByText } from '@testing-library/react';
+import flushPromises from '../../../test-utils/flushPromises';
 import ManuscriptUpload from './ManuscriptUpload';
-
-function flushPromises(ui: React.ReactElement<any>, container: HTMLElement) {
-    return new Promise(resolve =>
-        setImmediate(() => {
-            render(ui, { container });
-            resolve(container);
-        }),
-    );
-}
 
 function dispatchEvt(node: Document | Element | Window, type: string, data: any) {
     const event = new Event(type, { bubbles: true });
@@ -54,7 +46,7 @@ describe('ManuscriptUpload', (): void => {
 
         await act(async () => {
             dispatchEvt(dropzone, 'dragenter', data);
-            await flushPromises(ui, container);
+            await flushPromises();
         });
 
         expect(queryByText(container, 'manuscript-upload.active-content')).not.toBeNull();
@@ -77,7 +69,7 @@ describe('ManuscriptUpload', (): void => {
 
         await act(async () => {
             dispatchEvt(dropzone, 'dragenter', data);
-            await flushPromises(ui, container);
+            await flushPromises();
         });
 
         expect(queryByText(container, 'custom active content')).not.toBeNull();

--- a/client/src/ui/molecules/ManuscriptUpload.tsx
+++ b/client/src/ui/molecules/ManuscriptUpload.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
-import { default as UploadIcon } from '../atoms/UploadIcon';
 
 interface Props {
     inactiveContent?: string | JSX.Element | JSX.Element[];

--- a/client/test-utils/flushPromises.ts
+++ b/client/test-utils/flushPromises.ts
@@ -1,0 +1,9 @@
+function flushPromises() {
+  return new Promise(resolve =>
+      setTimeout(() => {
+          resolve();
+      }),
+  );
+}
+
+export default flushPromises;


### PR DESCRIPTION
closes #364 

Makes `flushPromise` a generic function for use throughout the tests. Fixes errors thrown by replacing the use of `setImmediate` to `setTimeout`.

Removes unused Icon dependency from component.

__we did attempt to use the `flush-promises` library, however this uses `setImmediate` in the context of our tests so still causes the error to be thrown__