### PR TITLE
Add migrations to audit service

### DIFF
--- a/audit/package.json
+++ b/audit/package.json
@@ -25,11 +25,13 @@
     "funfix": "^7.0.1",
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.19.4",
+    "knex-umzug": "^3.0.1",
     "node-fetch": "^2.6.0",
     "nodemon": "^1.19.1",
     "pg": "^7.12.1",
     "pino": "^5.13.2",
     "typescript": "^3.5.3",
+    "umzug-cli": "^2.0.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/audit/package.json
+++ b/audit/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "build": "tsc --build tsconfig.json",
     "lint": "tslint --project tsconfig.json",
+    "migrate": "ts-node src/migrate.ts",
     "start:dev": "dotenv -e ../.env -- nodemon --watch 'src/**/*.ts' --ignore 'src/**/*.spec.ts' --exec 'ts-node' src/main.ts | pino-pretty",
     "update:internal": "yarn upgrade -P @libero"
   },

--- a/audit/src/config.ts
+++ b/audit/src/config.ts
@@ -1,7 +1,7 @@
 import { Config as KnexConfig } from 'knex';
 
 const knexConfig: KnexConfig = {
-  dialect: 'pg',
+  client: 'pg',
   // In production we should use postgres pools.
   connection: {
     host: 'localhost',

--- a/audit/src/config.ts
+++ b/audit/src/config.ts
@@ -1,10 +1,10 @@
-import {Config as KnexConfig } from 'knex';
+import { Config as KnexConfig } from 'knex';
 
 const knexConfig: KnexConfig = {
   dialect: 'pg',
   // In production we should use postgres pools.
   connection: {
-    host: 'postgres',
+    host: 'localhost',
     user: 'postgres',
     database: 'reviewer_audit',
     password: 'postgres',

--- a/audit/src/migrate.ts
+++ b/audit/src/migrate.ts
@@ -1,0 +1,19 @@
+import * as umzugCli from 'umzug-cli';
+import * as Knex from 'knex';
+import Config from './config';
+
+const connection = Knex(Config.knex);
+
+console.log(Config.knex);
+
+umzugCli({
+    storage: 'knex-umzug',
+    storageOptions: {
+        context: 'default',
+        connection,
+        tableName: 'migrations',
+    },
+    migrations: {
+        path: `${__dirname}/migrations`
+    }
+}).cli(process.argv.slice(2));

--- a/audit/src/migrate.ts
+++ b/audit/src/migrate.ts
@@ -4,7 +4,7 @@ import Config from './config';
 
 const connection = Knex(Config.knex);
 
-console.log(Config.knex);
+console.log(`${__dirname}/migrations`);
 
 umzugCli({
     storage: 'knex-umzug',
@@ -14,6 +14,8 @@ umzugCli({
         tableName: 'migrations',
     },
     migrations: {
-        path: `${__dirname}/migrations`
+        params: [connection],
+        path: `${__dirname}/migrations`,
+        pattern: /.*\.ts/,
     }
 }).cli(process.argv.slice(2));

--- a/audit/src/migrations/1571139214-initial.ts
+++ b/audit/src/migrations/1571139214-initial.ts
@@ -1,35 +1,14 @@
 export default {
-  up (...args) {
-      console.log(args);
-    // return query.createTable('audit', {
-    //     id: {
-    //         type: DataTypes.UUID,
-    //         allowNull: false,
-    //         primaryKey: true,
-    //     },
-    //     subject: {
-    //         type: DataTypes,
-    //         allowNull: false,
-    //     },
-    //     verb: {
-    //         type: DataTypes.UUID,
-    //         allowNull: false,
-    //     },
-    //     entity: {
-    //         type: DataTypes.UUID,
-    //         allowNull: false,
-    //     },
-    // });
-
-    // await this.knex.schema.createTable(this.TABLE_NAME, (table) => {
-    //     table.string('id');
-    //     table.string('subject');
-    //     table.string('verb');
-    //     table.string('entity');
-    // });     
+  async up (knex) {
+    await knex.schema.createTable('audit', (table) => {
+        table.string('id');
+        table.string('subject');
+        table.string('verb');
+        table.string('entity');
+    });
   },
 
-  down (...args) {
-    console.log(args);
+  async down (knex) {
+    knex.schema.dropTable('audit');
   },
 };

--- a/audit/src/migrations/1571139214-initial.ts
+++ b/audit/src/migrations/1571139214-initial.ts
@@ -1,0 +1,35 @@
+export default {
+  up (...args) {
+      console.log(args);
+    // return query.createTable('audit', {
+    //     id: {
+    //         type: DataTypes.UUID,
+    //         allowNull: false,
+    //         primaryKey: true,
+    //     },
+    //     subject: {
+    //         type: DataTypes,
+    //         allowNull: false,
+    //     },
+    //     verb: {
+    //         type: DataTypes.UUID,
+    //         allowNull: false,
+    //     },
+    //     entity: {
+    //         type: DataTypes.UUID,
+    //         allowNull: false,
+    //     },
+    // });
+
+    // await this.knex.schema.createTable(this.TABLE_NAME, (table) => {
+    //     table.string('id');
+    //     table.string('subject');
+    //     table.string('verb');
+    //     table.string('entity');
+    // });     
+  },
+
+  down (...args) {
+    console.log(args);
+  },
+};

--- a/audit/src/repo/audit.ts
+++ b/audit/src/repo/audit.ts
@@ -4,23 +4,7 @@ import { InfraLogger as logger } from '../logger';
 import * as Knex from 'knex';
 
 export class KnexAuditRepository implements AuditRepository {
-  private TABLE_NAME = 'audit';
-
-  public constructor(private readonly knex: Knex<{}, unknown[]>) {
-    this.initTables();
-  }
-
-  private async initTables(): Promise<void> {
-    // this will eventually be replaced with migrations
-
-    await this.knex.schema.createTable(this.TABLE_NAME, (table) => {
-      table.string('id');
-      table.string('subject');
-      table.string('verb');
-      table.string('entity');
-    });
-
-  }
+  public constructor(private readonly knex: Knex<{}, unknown[]>) { }
 
   public async putLog( item: AuditLogItem ): Promise<boolean> {
 

--- a/audit/yarn.lock
+++ b/audit/yarn.lock
@@ -781,6 +781,14 @@ babel-preset-jest@^24.9.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.9.0"
 
+babel-runtime@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -825,6 +833,11 @@ bluebird@^3.5.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
   integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
 
+bluebird@^3.5.3:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
+
 bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
@@ -845,6 +858,11 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+borderless-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/borderless-table/-/borderless-table-2.0.0.tgz#efbf961800a47476f055de9d5cbf51d9b752a248"
+  integrity sha1-77+WGACkdHbwVd6dXL9R2bdSokg=
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -1175,6 +1193,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-js@^2.4.0:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3033,6 +3056,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+knex-umzug@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/knex-umzug/-/knex-umzug-3.0.1.tgz#1f0673c4a9d83e042b5956014f15e91e20aaac16"
+  integrity sha512-DUqRli6LP74xPxK+AQAM5Qn8XO5u2cYr3sTY+81kZmEiUuR9D5eMb21+7Q3OAz1Tr5yQBs5w/2a5b/8OGy38JQ==
+
 knex@^0.19.4:
   version "0.19.4"
   resolved "https://registry.yarnpkg.com/knex/-/knex-0.19.4.tgz#cf62f8824392387152a0a188a6585d5dea6832bb"
@@ -4154,6 +4182,11 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -4963,6 +4996,23 @@ uglify-js@^3.1.4:
     commander "2.20.0"
     source-map "~0.6.1"
 
+umzug-cli@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/umzug-cli/-/umzug-cli-2.0.0.tgz#9a8006e75822eb51e6c5d257d7af596554a6c3c7"
+  integrity sha1-moAG51gi61HmxdJX169ZZVSmw8c=
+  dependencies:
+    borderless-table "^2.0.0"
+    umzug "^2.0.0"
+    yargs-parser "^7.0.0"
+
+umzug@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/umzug/-/umzug-2.2.0.tgz#6160bdc1817e4a63a625946775063c638623e62e"
+  integrity sha512-xZLW76ax70pND9bx3wqwb8zqkFGzZIK8dIHD9WdNy/CrNfjWcwQgQkGCuUqcuwEBvUm+g07z+qWvY+pxDmMEEw==
+  dependencies:
+    babel-runtime "^6.23.0"
+    bluebird "^3.5.3"
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -5283,6 +5333,13 @@ yargs-parser@^13.1.1:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
+  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs@^13.3.0:
   version "13.3.0"


### PR DESCRIPTION
Closes #389 

- Adds umzug, umzug-cli and knex-umzug packages
- umzug-cli acts as a cli interface to umzug with knex-umzug providing knex storage for migrations table
- migrate.ts script to call umzug-cli

Notes
- umzug-cli hasn't been updated in 2 years, maybe we should have our own package?
- we'll probably need utility to create migration files in a standard way
