### PR TITLE
use postgres as default DB_HOST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SERVER_PORT=3000
 
 ## Database
 DB_TYPE=postgres
-DB_HOST=localhost
+DB_HOST=postgres
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres


### PR DESCRIPTION
sets DB_HOST to postgres in .env.example as we are expecting to use docker for running infrastructure