### PR TITLE
Added result column and use context for source

### DIFF
--- a/audit/src/domain/types.ts
+++ b/audit/src/domain/types.ts
@@ -2,6 +2,7 @@ export interface AuditLogItem {
   entity: string;
   action: string;
   object: string;
+  result?: unknown;
 }
 
 export interface AuditRepository {

--- a/audit/src/handlers/index.test.ts
+++ b/audit/src/handlers/index.test.ts
@@ -26,6 +26,10 @@ describe('UserLoggedInHandler', () => {
               userId: 'userId',
               email: 'email',
               timestamp: new Date(),
+              result: 'authorized',
+            },
+            context: {
+              source: 'source',
             },
             eventType: LiberoEventType.userLoggedInIdentifier,
         };
@@ -37,6 +41,7 @@ describe('UserLoggedInHandler', () => {
         expect(recordAudit).toHaveBeenCalledTimes(1);
         expect(auditItem.entity).toBe('user:userId');
         expect(auditItem.action).toBe('LOGGED_IN');
-        expect(auditItem.object).toBe('application');
+        expect(auditItem.object).toBe('source');
+        expect(auditItem.result).toBe('authorized');
     });
 });

--- a/audit/src/handlers/index.ts
+++ b/audit/src/handlers/index.ts
@@ -4,21 +4,21 @@ import { UserLoggedInPayload } from '@libero/libero-events';
 import { InfraLogger as logger } from '../logger';
 import { AuditController } from '../domain/audit';
 import { AuditLogItem } from '../domain/types';
-import { v4 } from 'uuid';
 
 export type EventHandler<T extends object> = (
   ...args
 ) => (ev: Event<T>) => Promise<boolean>;
 
 export const UserLoggedInHandler = (auditDomain: AuditController) => async (
-  ev: Event<UserLoggedInPayload>,
+  event: Event<UserLoggedInPayload>,
 ) => {
   const auditItem: AuditLogItem = {
-    entity: `user:${ev.payload.userId}`,
+    entity: `user:${event.payload.userId}`,
     action: 'LOGGED_IN',
-    object: 'application',
+    object: (event.context as { source: string }).source || '',
+    result: event.payload.result,
   };
 
-  logger.info('userLoggedInReceived', ev.payload);
+  logger.info('userLoggedInReceived', event.payload);
   return await auditDomain.recordAudit(auditItem);
 };

--- a/audit/src/migrations/1571139214-initial.ts
+++ b/audit/src/migrations/1571139214-initial.ts
@@ -6,6 +6,7 @@ export default {
       table.string('entity');
       table.string('action');
       table.string('object');
+      table.string('result');
       table.timestamp('created').defaultTo(knex.fn.now());
     });
   },

--- a/continuum-auth/src/use-cases/authenticate.ts
+++ b/continuum-auth/src/use-cases/authenticate.ts
@@ -80,10 +80,14 @@ export const Authenticate = (profilesService: ProfilesRepo, eventBus: EventBus) 
                             id: v4(),
                             created: new Date(),
                             eventType: LiberoEventType.userLoggedInIdentifier,
+                            context: {
+                                source: 'continuum-auth',
+                            },
                             payload: {
                                 name: profile.name.preferred,
                                 userId: payload.identity.user_id,
                                 email: profile.emailAddresses.length > 0 ? profile.emailAddresses[0].value : '',
+                                result: 'authorized',
                                 timestamp: new Date(),
                             },
                         };

--- a/lib/libero-events/src/events/index.ts
+++ b/lib/libero-events/src/events/index.ts
@@ -9,6 +9,7 @@ export interface UserLoggedInPayload {
   userId: string;
   email: string;
   timestamp: Date;
+  result: string;
 }
 
 export enum LiberoEventType { 


### PR DESCRIPTION
- Added result column to audit database initial migration
- Use Event context field for the event source
- Added result to user logged in event payload