### PR TITLE
add config example copys to make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ stop:
 	docker network rm infra_api
 	docker network rm infra_rabbit
 
-start: 
+start:
 	-docker network create infra_postgres
 	-docker network create infra_api
 	-docker network create infra_rabbit
@@ -14,6 +14,8 @@ start:
 
 setup:
 	if [ ! -e .env ] ; then ln -s .env.example .env ; fi
+	if [ ! -e ./config/server/config.json ] ; then cp config/server/config.example.json config/server/config.json ; fi
+	if [ ! -e ./config/server/newrelic.js ] ; then cp config/server/newrelic.example.js config/server/newrelic.js ; fi
 	git submodule init
 	git submodule update
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -8,7 +8,7 @@ Setup the configuration by running
 make setup
 ```
 
-This should get you started with a [default configuration](../.env.example) that works out of the box. Refer to the
+This should get you started with a [default env configuration](../.env.example), [config json file](../config/server/config.example.json) and [newrelic config file](../config/server/newrelic.example.js) that works out of the box. Refer to the
 [Configuration documentation](./configuration.md) for a more detailed description.
 
 


### PR DESCRIPTION
Add the copying of example config files to the `make setup` command.

closes #504