### PR TITLE
use environment variables for mocks service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       retries: 3
     environment:
       PORT: "3003"
-      CONTINUUM_LOGIN_JWT_SECRET: "some_secret_from_journal"
-      CONTINUUM_LOGIN_REDIRECT_URL: "http://localhost:3001/authenticate"
+      CONTINUUM_LOGIN_JWT_SECRET: "${AUTHENTICATION_JWT_SECRET}"
+      CONTINUUM_LOGIN_REDIRECT_URL: "${AUTHENTICATION_URL}"
     networks:
       - infra_api
 


### PR DESCRIPTION
updates docker-compose.yml to use environment variables to get redirected to client after journal login instead of continuum-auth