### PR TITLE
Improve Makefile to setup databases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE_INFRA = docker-compose -f docker-compose.infra.yml
+
 stop: 
 	docker-compose down
 	docker-compose -f docker-compose.infra.yml down
@@ -6,14 +9,24 @@ stop:
 	docker network rm infra_rabbit
 
 start:
+	$(MAKE) create_networks
+	-${DOCKER_COMPOSE_INFRA} up -d
+	-${DOCKER_COMPOSE} up -d
+	-${DOCKER_COMPOSE} exec audit node dist/migrate.js run
+	-${DOCKER_COMPOSE} exec continuum-adaptor node dist/migrate.js run
+
+create_networks:
 	-docker network create infra_postgres
 	-docker network create infra_api
 	-docker network create infra_rabbit
-	-docker-compose -f docker-compose.infra.yml up -d
-	-docker-compose up -d
 
 setup:
 	if [ ! -e .env ] ; then ln -s .env.example .env ; fi
+	$(MAKE) setup_gitmodules
+	$(MAKE) setup_config
+	${MAKE} setup_databases
+
+setup_config:
 	if [ ! -e ./config/audit/config.json ] ; then cp config/audit/config.example.json config/audit/config.json ; fi
 	if [ ! -e ./config/client/config.public.json ] ; then cp config/client/config.public.example.json config/client/config.public.json ; fi
 	if [ ! -e ./config/client/config.infra.json ] ; then cp config/client/config.infra.example.json config/client/config.infra.json ; fi
@@ -21,8 +34,21 @@ setup:
 	if [ ! -e ./config/reviewer-mocks/config.json ] ; then cp config/reviewer-mocks/config.example.json config/reviewer-mocks/config.json ; fi
 	if [ ! -e ./config/server/config.json ] ; then cp config/server/config.example.json config/server/config.json ; fi
 	if [ ! -e ./config/server/newrelic.js ] ; then cp config/server/newrelic.example.js config/server/newrelic.js ; fi
-	git submodule init
-	git submodule update
+
+setup_gitmodules:
+	git submodule update --init --recursive
+
+setup_databases:
+	$(MAKE) create_networks
+	-${DOCKER_COMPOSE_INFRA} up -d postgres
+	-${DOCKER_COMPOSE_INFRA} exec postgres psql -U postgres -c 'CREATE DATABASE reviewer_audit';
+	-${DOCKER_COMPOSE_INFRA} exec postgres psql -U postgres -c 'CREATE DATABASE reviewer_continuum_adaptor';
+	-${DOCKER_COMPOSE_INFRA} down
+
+clean_databases:
+	$(MAKE) create_networks
+	-${DOCKER_COMPOSE_INFRA} up -d postgres
+	-${DOCKER_COMPOSE_INFRA} down -v
 
 follow_logs:
 	-docker-compose -f docker-compose.yml logs -f

--- a/config/audit/config.example.json
+++ b/config/audit/config.example.json
@@ -3,10 +3,9 @@
     "rabbitmq_url": "rabbitmq",
     "database": {
         "type": "pg",
-        "name": "reviewer_audit",
         "host": "postgres",
         "username": "postgres",
-        "database": "postgres",
+        "database": "reviewer_audit",
         "port": 5432
     }
 }

--- a/config/continuum-adaptor/config.example.json
+++ b/config/continuum-adaptor/config.example.json
@@ -5,5 +5,15 @@
     "login_return_url": "http://localhost:9000/login",
     "authentication_jwt_secret": "super_secret_jam",
     "continuum_jwt_secret": "some_secret_from_journal",
-    "continuum_api_url": "http://reviewer-mocks:3003"
+    "continuum_api_url": "http://reviewer-mocks:3003",
+    "knex": {
+        "client": "pg",
+        "connection": {
+            "host": "postgres",
+            "database": "reviewer_continuum_adaptor",
+            "user": "postgres",
+            "password": "postgres",
+            "port": 5432
+        }
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     networks:
       - infra_api
       - infra_rabbit
+      - infra_postgres
 
   reviewer-mocks:
     image: liberoadmin/reviewer-mocks:latest


### PR DESCRIPTION
- Add setup_databases task to create audit and continuum-adaptor databases
- Run the migration on start
- Fix continuum-adaptor not being in infra_postgres
- Add clean_databases task
- Fix default configurations for audit and continuum-adaptor