### PR TITLE
add regex rules for minio and master-sha

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -50,7 +50,7 @@ services:
       - ./.data/etcd:/etcd-data
 
   s3:
-    image: minio/minio@sha256:56871a897ac0cdef94c7b83ae5d97424cf30a38626b2214cd70b5f0065850299
+    image: minio/minio:RELEASE.2020-03-25T07-03-04Z@sha256:5e96d539583afd9a7da14e0d9bf2360d316e4e8219659d82b8ef106a9d75b16c
     ports:
       - "9004:9000"
     volumes:
@@ -68,7 +68,7 @@ services:
       retries: 10
 
   s3_create-bucket:
-    image: minio/mc@sha256:5e2ce805faf722b3acc440453d39452a2f19cff6be41a29c80cbe6e8cb4f5b89
+    image: minio/mc:RELEASE.2020-03-14T01-23-37Z@sha256:571feb12447644c6fc91aa0364a639e308f4e3d6f827558a41254f0b7a648097
     depends_on:
       - s3
     networks:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "extends": [
     "config:base",
     ":automergeAll"
+  ],
+  "packageRules": [
+    {
+      "packageNames": ["^libero"],
+      "versioning": "regex:^master-(?<patch>\\w+)$"
+    },
+    {
+      "packageNames": ["^minio"],
+      "versioning": "regex:^RELEASE\\.(?<patch>\\.+)$"
+    }
   ]
 }


### PR DESCRIPTION
Our master-sha and minio's RELEASE. tags don't comply with standard tagging rules.

Also renovatebot doesn't support pinning of latest.