### PR TITLE
Improve renovate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,5 +13,9 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: Start services & Run Integration tests
+      - name: Integration Tests on stable
         run: make test_integration
+      - name: Integration Tests on master-images
+        run: |
+          make stop
+          make test_integration_master

--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,21 @@ clean_databases:
 follow_logs:
 	-docker-compose -f docker-compose.yml logs -f
 
-test_integration: setup
-	$(MAKE) create_networks
-	-${DOCKER_COMPOSE_INFRA} up -d
+wait_healthy:
 	./.scripts/docker/wait-healthy.sh reviewer_postgres_1 20
 	./.scripts/docker/wait-healthy.sh reviewer_s3_1 30
-	${DOCKER_COMPOSE} up -d
 	./.scripts/docker/wait-healthy.sh reviewer_reviewer-mocks_1 30
 	./.scripts/docker/wait-healthy.sh reviewer_submission_1 20
 	./.scripts/docker/wait-healthy.sh reviewer_client_1 20
+
+test_integration: setup
+	$(MAKE) create_networks
+	-${DOCKER_COMPOSE_INFRA} up -d
+	${DOCKER_COMPOSE} up -d
+	yarn test:integration
+
+test_integration_master: setup
+	$(MAKE) create_networks
+	-${DOCKER_COMPOSE_INFRA} up -d
+	${DOCKER_COMPOSE} -f docker-compose.master.yml up -d
 	yarn test:integration

--- a/docker-compose.master.yml
+++ b/docker-compose.master.yml
@@ -47,7 +47,7 @@ services:
       - infra_api
 
   submission:
-    image: liberoadmin/reviewer-submission:0.0.2
+    image: liberoadmin/reviewer-submission:master-32603a293b3f301f609b485b42c51bf3c8ef66af
     ports:
       - "3000:3000"
     environment:

--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,14 @@
   ],
   "packageRules": [
     {
-      "managers": ["dockerfile", "docker-compose"],
+      "paths": ["docker-compose.master.yml"],
       "packagePatterns": ["^libero"],
-      "versioning": "regex:^master-(?<patch>\\w+)$"
+      "versioning": "regex:^(?<compatibility>\\w+)-(?<hash>\\w+)$"
     },
     {
-      "managers": ["dockerfile", "docker-compose"],
+      "paths": ["docker-compose.infra.yml"],
       "packagePatterns": ["^minio"],
-      "versioning": "regex:^RELEASE\\.(?<patch>\\.+)$"
+      "versioning": "regex:^(?<compatibility>\\w+)"
     }
   ]
 }


### PR DESCRIPTION
- fix regexes (renovate really wants semver, so this is some trickery)
- introduce `docker-compose.master.yml` for tracking `master` of components  
  this might get moved to a `edge` branch  
  `docker-compose.yml` needs to switch to semver images ASAP