### PR TITLE
fix(ci): only use regexversioning where needed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,12 @@
   ],
   "packageRules": [
     {
+      "datasources": ["docker"],
       "packagePatterns": ["^minio"],
       "versioning": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})"
     },
     {
-      "paths": ["docker-compose.yml"],
+      "paths": ["docker-compose.master.yml"],
       "packagePatterns": ["^libero"],
       "versioning": "regex:^(?<compatibility>\\w+)-(?<hash>\\w{8})-(?<minor>\\d{8})\\.(?<patch>\\d{4})$"
     }


### PR DESCRIPTION
- limit minio regex to docker/compose files
- limit libero regex to `docker-compose.master.yml`