### PR TITLE
Add browsertest job to chart

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.4
+version: 0.14.5
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.0
+version: 0.14.1
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.5
+version: 0.14.6
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.3
+version: 0.14.4
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.1
+version: 0.14.2
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.14.2
+version: 0.14.3
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.13.1
+version: 0.14.0
 
 dependencies:
   - name: "postgresql"

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/instance: {{.Release.Name | quote }}
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
-    {{ if .Values.browsertests.runPostInstall }}
-    "helm.sh/hook": test-success,post-install
+    {{ if .Values.browsertests.runPostRelease }}
+    "helm.sh/hook": test-success,post-install,post-upgrade
     {{ else }}
     "helm.sh/hook": test-success
     {{ end }}

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{.Release.Name}}"
+  name: "{{.Release.Name}}-browsertests"
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}
@@ -33,4 +33,9 @@ spec:
           value: {{ .Values.browsertests.baseurl | default .Values.ingress.host | quote}}
         - name: TEST_FIXTURE
           value: {{ .Values.browsertests.testFixture }}
+        resources:
+          limits:
+            memory: 500Mi
+          requests:
+            memory: 350Mi
         

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -1,4 +1,4 @@
-{{- $tag := .Values.client.image.tag -}} 
+{{- $tag := .Values.client.image.tag -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,4 +41,3 @@ spec:
           requests:
             cpu: 200m
             memory: 350Mi
-        

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -14,7 +14,6 @@ metadata:
     "helm.sh/hook": test-success
     {{ end }}
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -14,6 +14,7 @@ metadata:
     "helm.sh/hook": test-success
     {{ end }}
     "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   backoffLimit: 1
   template:

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -1,0 +1,37 @@
+{{- $tag := .Values.client.image.tag -}} 
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    {{ if .Values.browsertests.runPostInstall }}
+    "helm.sh/hook": test-success,post-install
+    {{ else }}
+    "helm.sh/hook": test-success
+    {{ end }}
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: reviewer-browsertests
+        #Use same image tag as client; if the tag ends in a timestamp we strip it
+        image: '{{ .Values.browsertests.image.repository }}:{{ regexReplaceAll "-\\d{8}\\.\\d{4}$" $tag "" }}'
+        env:
+        - name: BASE_URL
+          value: {{ .Values.browsertests.baseurl | default .Values.ingress.host | quote}}
+        - name: TEST_FIXTURE
+          value: {{ .Values.browsertests.testFixture }}
+        

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -24,6 +24,7 @@ spec:
         helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
       restartPolicy: Never
+      backoffLimit: 1
       containers:
       - name: reviewer-browsertests
         #Use same image tag as client; if the tag ends in a timestamp we strip it

--- a/charts/libero-reviewer/templates/job-browsertests.yaml
+++ b/charts/libero-reviewer/templates/job-browsertests.yaml
@@ -15,6 +15,7 @@ metadata:
     {{ end }}
     "helm.sh/hook-weight": "-5"
 spec:
+  backoffLimit: 1
   template:
     metadata:
       name: "{{.Release.Name}}"
@@ -24,7 +25,6 @@ spec:
         helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     spec:
       restartPolicy: Never
-      backoffLimit: 1
       containers:
       - name: reviewer-browsertests
         #Use same image tag as client; if the tag ends in a timestamp we strip it
@@ -38,5 +38,6 @@ spec:
           limits:
             memory: 500Mi
           requests:
+            cpu: 200m
             memory: 350Mi
         

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -96,7 +96,7 @@ browsertests:
   image:
     # for the tag we use client.image.tag but strip timestamps
     repository: liberoadmin/reviewer-browsertests
-  runPostInstall: false
+  runPostRelease: false
   testFixture: all
   # baseurl defaults to .Values.ingress.host
   #baseurl: libero-reviewer--staging.domain.tld

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -91,3 +91,12 @@ ingress:
     annotations:
   auth:
     annotations:
+
+browsertests:
+  image:
+    # for the tag we use client.image.tag but strip timestamps
+    repository: liberoadmin/reviewer-browsertests
+  runPostInstall: false
+  testFixture: all
+  # baseurl defaults to .Values.ingress.host
+  #baseurl: libero-reviewer--staging.domain.tld


### PR DESCRIPTION
You can now run browsertests on the deployment:

- with `helm test`
- on each install/upgrade by setting a flag in `values.yml`

The tests to run can be set via an envvar (via `values.yml`)