### PR TITLE
fix(renovate): minio tag regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "datasources": ["docker"],
       "packagePatterns": ["^minio"],
-      "versioning": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})"
+      "versioning": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T\\d{2}-\\d{2}-\\d{2}Z$"
     },
     {
       "paths": ["docker-compose.yml"],


### PR DESCRIPTION
Limit tag regex to the default amd64 images.
Otherwise it picks up e.g. arm images.