### PR TITLE
give each component a unique app name

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.16.0
+version: 0.16.1
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt

--- a/charts/libero-reviewer/templates/deployment-client.yaml
+++ b/charts/libero-reviewer/templates/deployment-client.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "libero-reviewer.fullname" . }}-client
+  name: {{ include "libero-reviewer.fullname" . }}--client
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
+    app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--client
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
+      app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--client
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: client
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
+        app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--client
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: client
     spec:

--- a/charts/libero-reviewer/templates/deployment-client.yaml
+++ b/charts/libero-reviewer/templates/deployment-client.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "libero-reviewer.fullname" . }}-client
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: client
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--client
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: client
     spec:

--- a/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
+++ b/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "libero-reviewer.fullname" . }}-continuum-adaptor
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: continuum-adaptor
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: continuum-adaptor
     spec:

--- a/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
+++ b/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "libero-reviewer.fullname" . }}-continuum-adaptor
+  name: {{ include "libero-reviewer.fullname" . }}--continuum-adaptor
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
+    app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--continuum-adaptor
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
+      app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--continuum-adaptor
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: continuum-adaptor
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--continuum-adaptor
+        app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--continuum-adaptor
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: continuum-adaptor
     spec:

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "libero-reviewer.fullname" . }}-submission
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: submission
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}
+        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: submission
     spec:

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "libero-reviewer.fullname" . }}-submission
+  name: {{ include "libero-reviewer.fullname" . }}--submission
   labels:
-    app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
+    app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--submission
     helm.sh/chart: {{ include "libero-reviewer.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -12,13 +12,13 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
+      app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--submission
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: submission
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "libero-reviewer.name" . }}--submission
+        app.kubernetes.io/name: {{ include "libero-reviewer.fullname" . }}--submission
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: submission
     spec:


### PR DESCRIPTION
We need unique app names so that the canary rollout can find the correct pods.