### PR TITLE
fix(chart): upgrade chart to v7.0 for k8s 1.16

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.16.6
+version: 0.17.0
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt
 
 dependencies:
   - name: "postgresql"
-    version: "~6.2"
+    version: "~7.0"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -70,8 +70,6 @@ postgresql:
   enabled: true
   image:
     tag: "11.4.0"
-  statefulset:
-    apiVersion: v1
   persistence:
     enabled: false
   postgresqlDatabase: "postgres"


### PR DESCRIPTION
Old version of chart uses the apps/v1beta2 api.
This has be removed in k8s 1.16.

The method of setting the api version via values is not part of
the bitnami chart, so this is removed.