### PR TITLE
add chart release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.0.0-rc.1
         if: github.ref != 'refs/heads/master'
         with:
-          chart_repo_url: https://libero.github.io/reviewer
+          charts_repo_url: https://libero.github.io/reviewer
         env:
           CR_TOKEN: "${{ secrets.CHART_RELEASE_TOKEN }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,15 +53,23 @@ jobs:
           status: FAILED
           color: warning
 
-  lint-chart:
+  chart:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fetch history
         run: git fetch --prune --unshallow
-      - name: Run chart-testing (lint)
+      - name: Lint Chart
         id: lint
         uses: helm/chart-testing-action@v1.0.0-rc.1
         with:
           command: lint
+      - name: Configure Git for Chart Release
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Release Chart using GH-Pages
+        uses: helm/chart-releaser-action@v1.0.0-rc.1
+        env:
+          CR_TOKEN: "${{ secrets.CHART_RELEASE_TOKEN }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,10 +66,12 @@ jobs:
         with:
           command: lint
       - name: Configure Git for Chart Release
+        if: github.ref != 'refs/heads/master'
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Release Chart using GH-Pages
         uses: helm/chart-releaser-action@v1.0.0-rc.1
+        if: github.ref != 'refs/heads/master'
         env:
           CR_TOKEN: "${{ secrets.CHART_RELEASE_TOKEN }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,5 +73,7 @@ jobs:
       - name: Release Chart using GH-Pages
         uses: helm/chart-releaser-action@v1.0.0-rc.1
         if: github.ref != 'refs/heads/master'
+        with:
+          chart_repo_url: https://libero.github.io/reviewer
         env:
           CR_TOKEN: "${{ secrets.CHART_RELEASE_TOKEN }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,15 +65,8 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0-rc.1
         with:
           command: lint
-      - name: Configure Git for Chart Release
-        if: github.ref != 'refs/heads/master'
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Release Chart using GH-Pages
-        uses: helm/chart-releaser-action@v1.0.0-rc.1
+      - name: Publish Chart using GH-Pages
+        uses: stefanprodan/helm-gh-pages@master
         if: github.ref != 'refs/heads/master'
         with:
-          charts_repo_url: https://libero.github.io/reviewer
-        env:
-          CR_TOKEN: "${{ secrets.CHART_RELEASE_TOKEN }}"
+          token: "${{ secrets.CHART_RELEASE_TOKEN }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           command: lint
       - name: Publish Chart using GH-Pages
         uses: stefanprodan/helm-gh-pages@master
-        if: github.ref != 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           token: "${{ secrets.CHART_RELEASE_TOKEN }}"
           charts_url: https://libero.github.io/reviewer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,3 +70,4 @@ jobs:
         if: github.ref != 'refs/heads/master'
         with:
           token: "${{ secrets.CHART_RELEASE_TOKEN }}"
+          charts_url: https://libero.github.io/reviewer

--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.19.0
+version: 0.19.1
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt


### PR DESCRIPTION
closes #1248 which is needed to later pin the deployed chart version in #1246 