### PR TITLE
feat(chart): add timeouts and sticky connections

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.23.4
+version: 0.24.0
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: submission
     spec:
+      terminationGracePeriodSeconds: {{ .Values.submission.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}-submission
           image: "{{ .Values.submission.image.repository }}:{{ .Values.submission.image.tag }}"

--- a/charts/libero-reviewer/templates/ingress-submission.yaml
+++ b/charts/libero-reviewer/templates/ingress-submission.yaml
@@ -11,6 +11,14 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "{{ div .Values.submission.maxFileSizeInBytes 1000000 }}m"
+    nginx.ingress.kubernetes.io/worker-shutdown-timeout: {{ .Values.submission.nginxWorkerTimeoutSeconds }}
+    {{- if .Values.submission.enableStickyConnections }}
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "3600"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "3600"
+    nginx.ingress.kubernetes.io/affinity-mode: "persistent"
+    nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
+    {{- end }}
 {{- with .Values.ingress.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -14,6 +14,13 @@ submission:
     enabled: false
     minAvailable: 1
     maxUnavailable: ""
+  # Timeout to give long requests a chance to complete before terminating the pod
+  # terminationGracePeriodSeconds is the total time allowed for:
+  #   preStop _and_ SIGTERM
+  terminationGracePeriodSeconds: 150
+  # Keep existing connections alive during ingress-controller reloads and during pod termination
+  nginxWorkerTimeoutSeconds: 120
+  enableStickyConnections: true
 
   newRelicHome: /etc/reviewer
   # Sets both an submission internal value as well as ingree max_request


### PR DESCRIPTION
terminationGracePeriod for container and nginxWorkerTimeout can be set via chart values.

Cookie based session affinity ingress annotations via boolean toggle.
Enabled by default.