### PR TITLE
1107 add new relic

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.27.0
+version: 0.28.0
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt

--- a/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
+++ b/charts/libero-reviewer/templates/deployment-continuum-adaptor.yaml
@@ -93,3 +93,19 @@ spec:
             {{- end }}
             - name: DATABASE_PORT
               value: "5432"
+
+            {{- if .Values.newRelic.enabled }}
+            - name: INCLUDE_NEW_RELIC
+              value: "true"
+            - name: NEW_RELIC_APP_NAME
+              value: {{ .Values.newRelic.appName | quote }}
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.newRelic.licenseKeyName | quote }}
+                    key: key
+            {{- range $name, $value := .Values.newRelic.additionalEnvironmentVariables }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -50,8 +50,6 @@ spec:
                     key: reviewer-auth-secret
             - name: USER_API_URL
               value: 'http://{{ include "libero-reviewer.fullname" . }}-continuum-adaptor:{{ .Values.continuumAdaptor.port }}'
-            - name: NEW_RELIC_HOME
-              value: "{{ .Values.submission.newRelicHome }}"
             - name: MAX_FILE_SIZE_IN_BYTES
               value: "{{ .Values.submission.maxFileSizeInBytes }}"
 

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -160,6 +160,22 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.submission.meca.apiSecret | quote }}
                     key: key
+            
+            {{- if .Values.newRelic.enabled }}
+            - name: INCLUDE_NEW_RELIC
+              value: "true"
+            - name: NEW_RELIC_APP_NAME
+              value: {{ .Values.newRelic.appName | quote }}
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.newRelic.licenseKeyName | quote }}
+                    key: key
+            {{- range $name, $value := .Values.newRelic.additionalEnvironmentVariables }}
+            - name: {{ $name }}
+              value: {{ $value }}
+            {{- end }}
+            {{- end }}
 
       initContainers:
         - name: {{ .Chart.Name }}-load-db-schema

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -156,3 +156,22 @@ reporter:
   image:
     repository: liberoadmin/reviewer-reporter
     tag: latest
+
+newRelic:
+  enabled: false
+  appName: libero-reviewer
+  # newRelic.licenseKeySecret -- Name of an existing secret with a 'key' entry
+  licenseKeySecret: ""
+  additionalEnvironmentVariables:
+    NEW_RELIC_DISTRIBUTED_TRACING_ENABLED: "true"
+    NEW_RELIC_ATTRIBUTES_EXCLUDE: >
+      'request.headers.cookie',
+      'request.headers.authorization',
+      'request.headers.proxyAuthorization',
+      'request.headers.setCookie*',
+      'request.headers.x*',
+      'response.headers.cookie',
+      'response.headers.authorization',
+      'response.headers.proxyAuthorization',
+      'response.headers.setCookie*',
+      'response.headers.x*'

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -23,7 +23,6 @@ submission:
   nginxWorkerTimeoutSeconds: 120
   enableStickyConnections: true
 
-  newRelicHome: /etc/reviewer
   # submission.maxFileSizeInBytes -- sets both an submission internal value as well as ingree max_request
   maxFileSizeInBytes: 100000000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,6 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEW_RELIC_HOME: /etc/reviewer
       DATABASE_NAME: postgres
       DATABASE_USER: postgres
       DATABASE_PASSWORD: postgres


### PR DESCRIPTION
- remove obsolete use of `NEW_RELIC_HOME` to point at `newrelic.json` (using envvars now)
- enable/disable newrelic via chart
- arbitrary config changes possible by adding envvars to `additonalEnvironmentVariables` in values