### PR TITLE
remove ci-semver job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,29 +7,6 @@ on:
       - master
 
 jobs:
-  ci-semver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - name: Run browsertest container against latest semver images
-        run: make test_integration
-      - name: Dump logs on failure
-        if: failure()
-        run: |
-          docker-compose -f docker-compose.infra.yml logs
-          docker-compose -f docker-compose.yml logs
-      - name: Notify slack
-        if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: libero-reviewer-tech
-          status: FAILED
-          color: danger
-
   ci-master:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently semver of the components lags waaaay behind master.

We've had to change the nginx config for master and since this is share with semver it breaks the pipeline.

I we want to use semver we can retag the components and then revert this PR. Currently my feeling is that we don't need semver as our components are not reused by others and the branch-hash-date tags work just fine.

If we don't end up using semver I'd make another PR to tidy up the makefile, dockerfile etc. I've got a reminder in #1268 