### PR TITLE
Only init db if zero tables exist

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.29.0
+version: 0.29.1
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt

--- a/charts/libero-reviewer/templates/deployment-submission.yaml
+++ b/charts/libero-reviewer/templates/deployment-submission.yaml
@@ -182,7 +182,7 @@ spec:
       initContainers:
         - name: {{ .Chart.Name }}-load-db-schema
           image: "{{ .Values.submissionDbSchema.image.repository }}:{{ .Values.submissionDbSchema.image.tag }}"
-          command: ["sh", "-c", "(psql -q -t -c \"select count(*) from information_schema.tables where table_schema='public';\" | xargs ) && psql -f  /docker-entrypoint-initdb.d/xpub-schema.sql"]
+          command: ["sh", "-c", "psql -q -t -c \"select count(*) from information_schema.tables where table_schema='public';\" | xargs | grep ^0$ && psql -f  /docker-entrypoint-initdb.d/xpub-schema.sql"]
           env:
             {{- if .Values.postgresql.enabled }}
             - name: PGHOST


### PR DESCRIPTION
Closes #1349 

The previous command already ran a query to count the existing tables. `xargs` strips the whitespace but always returns an exit code of 0, so the the psql apply of the schema always gets run.

I used grep to check if the output actually is 0.