### PR TITLE
Move reporter config from file to envvars

### DIFF
--- a/charts/libero-reviewer/Chart.yaml
+++ b/charts/libero-reviewer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "latest"
 description: elife specific deployment of Libero Reviewer
 name: libero-reviewer
-version: 0.32.0
+version: 0.33.0
 home: "https://github.com/libero/reviewer"
 maintainers:
   - name: erkannt

--- a/charts/libero-reviewer/templates/cronJob-reporter.yaml
+++ b/charts/libero-reviewer/templates/cronJob-reporter.yaml
@@ -52,13 +52,26 @@ spec:
               {{- end }}
               - name: PGPORT
                 value: "5432"
+              - name: MAILER_HOST
+                    secretKeyRef:
+                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      key: mailerhost
+              - name: MAILER_PORT
+                    secretKeyRef:
+                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      key: mailerport
+              - name: MAILER_AUTH_USER
+                    secretKeyRef:
+                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      key: user
+              - name: MAILER_AUTH_PASS
+                    secretKeyRef:
+                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      key: password
           volumes:
           - name: mailheader
             configMap:
               name: {{ $fullname }}-reporter-mailheader
-          - name: ssmtp
-            secret:
-              secretName: {{ $.Values.reporter.ssmtpConfSecret }}
           restartPolicy: OnFailure
 ---
 {{- end }}

--- a/charts/libero-reviewer/templates/cronJob-reporter.yaml
+++ b/charts/libero-reviewer/templates/cronJob-reporter.yaml
@@ -22,6 +22,26 @@ spec:
             env:
               - name: RECIPIENT
                 value: "{{ $.Values.reporter.recipient }}"
+              - name: MAILER_HOST
+                valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
+                      key: mailerhost
+              - name: MAILER_PORT
+                valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
+                      key: mailerport
+              - name: MAILER_AUTH_USER
+                valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
+                      key: user
+              - name: MAILER_AUTH_PASS
+                valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
+                      key: password
               {{- if $.Values.postgresql.enabled }}
               - name: PGHOST
                 value: '{{ include "libero-reviewer.fullname" . }}-postgresql'
@@ -33,7 +53,7 @@ spec:
                       name: {{ $.Values.postgresql.existingSecret | quote }}
                       key: postgresql-password
               - name: PGDATABASE
-                value: {{ $.Values.postgresql.postgresqlDatabase }}
+                value: "{{ $.Values.postgresql.postgresqlDatabase }}"
               {{- else }}
               - name: PGDATABASE
                 value: {{ $.Values.database.dbName | quote }}
@@ -49,22 +69,6 @@ spec:
               {{- end }}
               - name: PGPORT
                 value: "5432"
-              - name: MAILER_HOST
-                    secretKeyRef:
-                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
-                      key: mailerhost
-              - name: MAILER_PORT
-                    secretKeyRef:
-                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
-                      key: mailerport
-              - name: MAILER_AUTH_USER
-                    secretKeyRef:
-                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
-                      key: user
-              - name: MAILER_AUTH_PASS
-                    secretKeyRef:
-                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
-                      key: password
           volumes:
           - name: mailheader
             configMap:

--- a/charts/libero-reviewer/templates/cronJob-reporter.yaml
+++ b/charts/libero-reviewer/templates/cronJob-reporter.yaml
@@ -33,7 +33,7 @@ spec:
                       name: {{ $.Values.postgresql.existingSecret | quote }}
                       key: postgresql-password
               - name: PGDATABASE
-                value: "{{ $.Values.postgresql.postgresqlDatabase }}"
+                value: {{ $.Values.postgresql.postgresqlDatabase }}
               {{- else }}
               - name: PGDATABASE
                 value: {{ $.Values.database.dbName | quote }}

--- a/charts/libero-reviewer/templates/cronJob-reporter.yaml
+++ b/charts/libero-reviewer/templates/cronJob-reporter.yaml
@@ -19,9 +19,6 @@ spec:
             - name: mailheader
               mountPath: "/mail-config"
               readOnly: true
-            - name: ssmtp
-              mountPath: /etc/ssmtp
-              readOnly: true
             env:
               - name: RECIPIENT
                 value: "{{ $.Values.reporter.recipient }}"

--- a/charts/libero-reviewer/templates/cronJob-reporter.yaml
+++ b/charts/libero-reviewer/templates/cronJob-reporter.yaml
@@ -51,19 +51,19 @@ spec:
                 value: "5432"
               - name: MAILER_HOST
                     secretKeyRef:
-                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
                       key: mailerhost
               - name: MAILER_PORT
                     secretKeyRef:
-                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
                       key: mailerport
               - name: MAILER_AUTH_USER
                     secretKeyRef:
-                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
                       key: user
               - name: MAILER_AUTH_PASS
                     secretKeyRef:
-                      name: {{ .Values.reporter.ssmtpSecret | quote }}
+                      name: {{ $.Values.reporter.ssmtpSecret | quote }}
                       key: password
           volumes:
           - name: mailheader

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -149,8 +149,8 @@ reporter:
   fromAddress: no-reply@elifesciences.org
   subjectline: Reviewer Status Report
   recipient: ""
-  # reporter.ssmtpConfSecret -- ssmtp.conf file stored as secret, see also libero/reviewer-reporter
-  ssmtpConfSecret: ""
+  # reporter.ssmtpSecret -- name of existing secret with 'user', 'password', 'mailhost' and 'mailerport'
+  ssmtpSecret: ""
   # reporter.schedules -- list of 'name', 'schedule'(cron syntax) pairs
   schedules:
     - name: 8am

--- a/charts/libero-reviewer/values.yaml
+++ b/charts/libero-reviewer/values.yaml
@@ -150,7 +150,7 @@ reporter:
   subjectline: Reviewer Status Report
   recipient: ""
   # reporter.ssmtpSecret -- name of existing secret with 'user', 'password', 'mailhost' and 'mailerport'
-  ssmtpSecret: ""
+  ssmtpSecret: "libero-reviewer--prod-reporter-ssmtp"
   # reporter.schedules -- list of 'name', 'schedule'(cron syntax) pairs
   schedules:
     - name: 8am


### PR DESCRIPTION
This should fit with the way startup generates a config file using ENVVARs without relying on the mapped volume being read only which currently throws a non-failing error in production. 